### PR TITLE
Patch gen_salt werkzeug circular import error

### DIFF
--- a/application/admin.py
+++ b/application/admin.py
@@ -19,6 +19,7 @@ from flask_login import (
 )
 import os
 from application.database import db, Admin, Posts, Subscribers, BodyImages
+from werkzeug.security import check_password_hash
 
 bp = Blueprint('admin', __name__, url_prefix='/admin')
 
@@ -52,7 +53,7 @@ def login():
     if request.method == "POST":
         email = request.form["email"]
         user = Admin.query.get(email)
-        if user is not None and user.check_password(request.form["password"]):
+        if user is not None and check_password_hash(user.password_hash, (request.form["password"])):
             login_user(user)
             flash("What would you like to do today?")
             return redirect(url_for("admin.admin"))

--- a/application/database.py
+++ b/application/database.py
@@ -1,5 +1,4 @@
 import datetime
-from werkzeug.security import generate_password_hash, check_password_hash
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
@@ -77,13 +76,10 @@ class Admin(db.Model):
     password_hash = db.Column(db.String)
     authenticated = db.Column(db.Boolean)
 
-    def __init__(self, email, password):
+    def __init__(self, email, password_hash):
         self.email = email
-        self.password_hash = generate_password_hash(password)
+        self.password_hash = password_hash
         self.authenticated = False
-
-    def check_password(self, password):
-        return check_password_hash(self.password_hash, password)
 
     def is_active(self):
         """True, as all users are active."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from application.database import Admin, db, Posts, Subscribers
 import io
 import os
 from tests import setup_db, teardown_db, clean_db
+from werkzeug.security import generate_password_hash
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ def client(app):
 
 @pytest.fixture
 def admin_user():
-    return Admin("kelly", "kelly")
+    return Admin("kelly", generate_password_hash("kelly"))
 
 
 @pytest.fixture

--- a/tests/functionaltests/test_admin.py
+++ b/tests/functionaltests/test_admin.py
@@ -33,10 +33,9 @@ def test_login_post(client, app):
     WHEN the '/login' page is posted to (POST)
     THEN check that response is valid and person is logged in
     """
-    with app.app_context():
-        admin = Admin.query.filter_by(email="kelly").first()
-        assert admin.check_password("kelly")
-    response = login(client, admin.email, "kelly")
+    response = client.post(
+        "admin/login", data={"email": "kelly", "password": "kelly"}, follow_redirects=True
+        )
     assert response.status_code == 200
     assert b"What would you like to do today?" in response.data
 

--- a/tests/unittests/test_models.py
+++ b/tests/unittests/test_models.py
@@ -64,7 +64,7 @@ def test_admin():
     THEN also check that methods are properly defined
     """
     email = "nelly@kelly.com"
-    password = "weeeeeeeeeeee"
+    password = "weeeeeeeeeeee" #this is not encrypted but should be when sending to database
 
     admin = Admin(email, password)
 
@@ -73,7 +73,6 @@ def test_admin():
     # assert admin.password_hash == generate_password_hash(password)
     assert admin.authenticated is False
 
-    assert admin.check_password(password) is True
     # none of these return what they're supposed to according to the code I copied
     # hence why I'm going to remove flask-login
     # assert admin.is_active is True


### PR DESCRIPTION
Patches circular import error that started occuring after I seperated the database code into a seperate module. Fixed it by moving the check_password_hash from within the database to within the admin blueprint. This function is used for logging users in. Now when a new admin is added to the database I have to manually create the password hash. I plan to create a 'register' route to make this simpler. I'm not in any hurry because I am the only admin.