### PR TITLE
Fix front-end/back-end connection for subscribe method.

### DIFF
--- a/application/blog.py
+++ b/application/blog.py
@@ -63,7 +63,7 @@ def subscribe():
     last = request.form["last"]
     email = request.form["email"]
     if Subscribers.query.filter_by(email=email).first():
-        return "Sorry this email is already subscribed"
+        return "Database Integrity Error", "200 Duplicate Email"
     data = Subscribers(first, last, email)
     db.session.add(data)
     db.session.commit()
@@ -74,10 +74,7 @@ def subscribe():
     msg.body = f"Hello {first},\nThanks for subscribing!\nBest,\n Kelly"
     msg.html = render_template("/emails/welcome.html", name=first)
     mail.send(msg)
-
-    # have this automatically send a welcome email to confirm people.
-    # maybe this should return some URL so we know that the person is subscribed?
-    return "", 204
+    return "", 200
 
 
 @bp.route('/rss')

--- a/application/static/scripts.js
+++ b/application/static/scripts.js
@@ -1,3 +1,4 @@
+// Dynamic phone menu
 function showMenu() {
     // expand phone header menu
     const phone_menu_btn = document.getElementById('phone-menu-btn');
@@ -38,12 +39,50 @@ window.onclick = function(event) {
     }
 };
 
-// Display message when someone subscribes.
-var subscribe_signup = document.getElementById('subscribe_signup');
+// Handle Interactive subscribe popup
+var subscribe_form = document.getElementById('subscribe-form');
+var dup_email_message = document.getElementById('subscribe-dup-email-message');
+subscribe_form.addEventListener("submit", subscribe_handler);
 
-subscribe_signup.onclick = function() {
-    var form = document.getElementById('subscribe_form')
-    var message = document.getElementById('subscribe_message')
-    form.style.display = 'none';
-    message.style.display = 'block';
-};
+async function subscribe_handler(event) {
+    /* send subscriber and retrieve json representation */
+    const response = await ajaxifyForm(event);
+
+    console.log(response);
+
+    if (response.statusText == "Duplicate Email") {
+        dup_email_message.style.display = 'block';
+    }
+    else if (response.status == 200) {
+        var form = document.getElementById('subscribe-form')
+        var message = document.getElementById('subscribe-success-message')
+        var initial_message = document.getElementById('initial-subscribe-message');
+        form.style.display = 'none';
+        initial_message.style.display = 'none';
+        dup_email_message.style.display = 'none';
+        message.style.display = 'block';
+    }
+}
+
+async function ajaxifyForm(event) {
+    /* we don't want the usual behaviors (like reloading the page) */
+    event.preventDefault();
+
+    /* get the form, then populate a new FormData from it. */
+    var form = event.target;
+    var formData = new FormData(form);
+
+    /* get the route that the form sends data to */
+    var url = form.action;
+
+    /* submit the request. Careful modifying this - it was the source of many a headache. */
+    return await fetch(url, {
+    method : 'POST',
+    mode: 'cors',
+    credentials: 'same-origin',
+    cache : "no-cache",
+    referrerPolicy: 'no-referrer',
+    redirect: 'follow',
+    body: formData,
+    });
+}

--- a/application/static/styles.css
+++ b/application/static/styles.css
@@ -257,12 +257,19 @@ h2 .uncolored-link, .uncolored-link {
 	border-bottom: None;
 }
 
+/* --- Other ---- */
+
+.error-message {
+	/* used in subscribe form and login */
+	color: red;
+}
+
 /* =================================
 	Unique Element Styles
 ==================================== */
 
 /* Initially Hide Subscribe Message In Subscribe Modal */
-#subscribe_message {
+#subscribe-success-message, #subscribe-dup-email-message {
 	display:none;
 }
 

--- a/application/templates/admin/login.html
+++ b/application/templates/admin/login.html
@@ -7,7 +7,7 @@
 {% block main %}
 <form action="/admin/login" method="POST" class="container" id='login'>
     {% if message %}
-    <p style="color: red;">{{ message }}</p>
+    <p class='error-message'>{{ message }}</p>
     {% else %}
     <h4>Knock, knock, who's there?</h4>
     {% endif %}

--- a/application/templates/layout.html
+++ b/application/templates/layout.html
@@ -33,14 +33,15 @@
         <!-- Modal content -->
         <div class="modal-content small-width-element">
         <span class="close" id='modal_close'>&times;</span>
-        <form action="/subscribe" method="POST" id='subscribe_form'>
-            <h2>Let's stay in touch!</h2>
-            <input class="form-element" autofocus name="first" placeholder="First Name" type="text" required>
+        <h2 id='initial-subscribe-message'>Let's stay in touch!</h2>
+        <p class='error-message' id="subscribe-dup-email-message">This email is already subscribed, try another.</p>
+        <form action="/subscribe" method="POST" id='subscribe-form'>
+            <input class="form-element" autofocus name="first" placeholder="First Name" type="text">
             <input class="form-element" name="last" placeholder="Last Name" type="text">
-            <input class='form-element' name='email' placeholder='Email' type='text'>
+            <input class='form-element' name='email' placeholder='Email' type="email" required>
             <button id='subscribe_signup' type="submit">Sign up</button>
         </form>
-        <h3 id="subscribe_message">I'll be in touch soon!</h3>
+        <h3 id="subscribe-success-message">I'll be in touch soon!</h3>
         </div>
     </div>
     <hr>


### PR DESCRIPTION
If the email is a duplicate, a message will be shown to the user telling them to enter another email.
The old "Success" message is only shown if it's an actual success.
Updated tests.